### PR TITLE
Rename branding to CAMPFIRE AI Studio

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   
   <!-- Primary Meta Tags -->
-  <title>CAMPFIRE.AI Studio - AI Art & Visual Storytelling</title>
-  <meta name="title" content="CAMPFIRE.AI Studio - AI Art & Visual Storytelling | Andrew"/>
-  <meta name="description" content="Professional AI-generated art and visual storytelling for brands, agencies, and creators. Photorealistic interior design, hospitality, culinary, and retail visuals by Andrew at CAMPFIRE.AI Studio."/>
+  <title>CAMPFIRE AI Studio - AI Art & Visual Storytelling</title>
+  <meta name="title" content="CAMPFIRE AI Studio - AI Art & Visual Storytelling | Andrew"/>
+  <meta name="description" content="Professional AI-generated art and visual storytelling for brands, agencies, and creators. Photorealistic interior design, hospitality, culinary, and retail visuals by Andrew at CAMPFIRE AI Studio."/>
   <meta name="keywords" content="AI art, generative AI, visual storytelling, interior design visuals, hospitality art, retail advertising, brand imagery, photorealistic AI, custom artwork, campfire ai studio"/>
-  <meta name="author" content="Andrew - CAMPFIRE.AI Studio"/>
+  <meta name="author" content="Andrew - CAMPFIRE AI Studio"/>
   <meta name="robots" content="index, follow"/>
   
   <!-- Canonical URL -->
@@ -18,17 +18,17 @@
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website"/>
   <meta property="og:url" content="https://campfireaistudio.com"/>
-  <meta property="og:title" content="CAMPFIRE.AI Studio - AI Art & Visual Storytelling"/>
+  <meta property="og:title" content="CAMPFIRE AI Studio - AI Art & Visual Storytelling"/>
   <meta property="og:description" content="Professional AI-generated art and visual storytelling for brands, agencies, and creators. Photorealistic visuals that bring ideas to life."/>
   <meta property="og:image" content="https://campfireaistudio.com/campfireai_portfolio/campfirehero.jpg"/>
   <meta property="og:image:width" content="1200"/>
   <meta property="og:image:height" content="630"/>
-  <meta property="og:site_name" content="CAMPFIRE.AI Studio"/>
+  <meta property="og:site_name" content="CAMPFIRE AI Studio"/>
   
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image"/>
   <meta property="twitter:url" content="https://campfireaistudio.com"/>
-  <meta property="twitter:title" content="CAMPFIRE.AI Studio - AI Art & Visual Storytelling"/>
+  <meta property="twitter:title" content="CAMPFIRE AI Studio - AI Art & Visual Storytelling"/>
   <meta property="twitter:description" content="Professional AI-generated art and visual storytelling for brands, agencies, and creators. Photorealistic visuals that bring ideas to life."/>
   <meta property="twitter:image" content="https://campfireaistudio.com/campfireai_portfolio/campfirehero.jpg"/>
   <meta property="twitter:creator" content="@campfireai"/>
@@ -37,15 +37,15 @@
   <!-- Additional SEO Meta Tags -->
   <meta name="theme-color" content="#000000"/>
   <meta name="msapplication-TileColor" content="#000000"/>
-  <meta name="application-name" content="CAMPFIRE.AI Studio"/>
+  <meta name="application-name" content="CAMPFIRE AI Studio"/>
   
   <!-- Structured Data (JSON-LD) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "CreativeWork",
-    "name": "CAMPFIRE.AI Studio",
-    "alternateName": "CAMPFIRE.AI",
+    "name": "CAMPFIRE AI Studio",
+    "alternateName": "CAMPFIRE AI Studio",
     "url": "https://campfireaistudio.com",
     "description": "Professional AI-generated art and visual storytelling for brands, agencies, and creators",
     "creator": {
@@ -675,7 +675,7 @@
 </head>
 <body>
   <header>
-    <h1>CAMPFIRE.AI</h1>
+    <h1>CAMPFIRE AI Studio</h1>
     <div class="hamburger" id="hamburger">
       <span></span><span></span><span></span>
     </div>
@@ -695,7 +695,7 @@
 
 <section id="about">
   <h2>About</h2>
-  <p>Hey, I'm Andrew, creator behind CAMPFIRE.AI. I use generative AI to bring ideas to life through art that feels human. Using cutting-edge models and a keen eye for realism, I create visuals that are photorealistic and thoughtfully crafted. Whether you're a brand, agency, or independent creator, I focus on your objectives, creating visuals that make them a reality. Let's work together to build something unique.</p>
+  <p>Hey, I'm Andrew, creator behind CAMPFIRE AI Studio. I use generative AI to bring ideas to life through art that feels human. Using cutting-edge models and a keen eye for realism, I create visuals that are photorealistic and thoughtfully crafted. Whether you're a brand, agency, or independent creator, I focus on your objectives, creating visuals that make them a reality. Let's work together to build something unique.</p>
 </section>
 
   <section id="portfolio">


### PR DESCRIPTION
## Summary
- Replace all instances of "CAMPFIRE.AI" and "CAMPFIRE.AI Studio" with "CAMPFIRE AI Studio" across the site.
- Update header and About section to display the new brand name.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bfae828888333ad632b45c7d6d82a